### PR TITLE
doorbell: wait until an ip address is assigned

### DIFF
--- a/doorbell-service/esp8266-nodemcu/init.lua
+++ b/doorbell-service/esp8266-nodemcu/init.lua
@@ -9,8 +9,8 @@ local BACKEND_SERVICE_URL = "http://<BACKEND_SERVICE_HOST>/api/chat.postMessage"
   "&text=%40here%3a+Someone%20is%20ringing%20the%20door%20bell!"
 
 function wait_until(condition, action)
-  local WAIT_SECONDS = 2
-  tmr.alarm(0, WAIT_SECONDS * 1000, 1, function()
+  local WAIT_TIME = 150
+  tmr.alarm(0, WAIT_TIME, 1, function()
     if condition() then
       tmr.stop(0)
       action()

--- a/doorbell-service/esp8266-nodemcu/init.lua
+++ b/doorbell-service/esp8266-nodemcu/init.lua
@@ -1,32 +1,36 @@
-wifi.setmode(wifi.STATION)
-wifi.sta.config("<WIFI_NAME>", "<WIFI_PASSWORD>")
+local WIFI_SSID = "<WIFI_SSID>"
+local WIFI_PASSWORD = "<WIFI_PASSWORD>"
+local BACKEND_SERVICE_URL = "http://<BACKEND_SERVICE_HOST>/api/chat.postMessage" ..
+  "?token=<TOKEN>" ..
+  "&channel=<CHANNEL_ID>" ..
+  "&username=Doorbell%20Bot" ..
+  "&icon_url=http%3a%2f%2fimg.ctrlv.in%2fimg%2f16%2f01%2f21%2f56a0c2a544ad8.png" ..
+  "&link_names=1" ..
+  "&text=%40here%3a+Someone%20is%20ringing%20the%20door%20bell!"
 
-function fire_slack_request()
-    local door_bell_request =
-      "POST /api/chat.postMessage" ..
-      "?token=<TOKEN>" ..
-      "&channel=<CHANNEL_ID>" ..
-      "&username=Doorbell%20Bot" ..
-      "&icon_url=http%3a%2f%2fimg.ctrlv.in%2fimg%2f16%2f01%2f21%2f56a0c2a544ad8.png" ..
-      "&link_names=1&text=%40here%3a+Someone%20is%20ringing%20the%20door%20bell! HTTP/1.1\r\n" ..
-      "Host: <SERVICE_HOST>\r\n" ..
-      "Connection: keep-alive\r\nAccept: */*\r\n\r\n"
-
-    conn=net.createConnection(net.TCP, 0)
-    conn:on("connection", function(c)
-        print("Ding dong!")
-        conn:send(door_bell_request)
-    end)
-    conn:on("sent", function(c)
-        print("Sent.")
-    end)
-
-    conn:connect(<BACKEND_SERVICE_PORT>, "<BACKEND_SERVICE>")
+function wait_until(condition, action)
+  local WAIT_SECONDS = 2
+  tmr.alarm(0, WAIT_SECONDS * 1000, 1, function()
+    if condition() then
+      tmr.stop(0)
+      action()
+    else
+      tmr.start(0)
+    end
+  end)
 end
 
-fire_slack_request()
+wifi.setmode(wifi.STATION)
+wifi.sta.config(WIFI_SSID, WIFI_PASSWORD)
 
-tmr.alarm(0, 20 * 1000, 0, function()
-    print("Couldn't make the request, going to sleep.")
+wait_until(wifi.sta.getip, function()
+  http.post(BACKEND_SERVICE_URL, nil, nil, function(code, data)
+    if code < 0 then
+      print("HTTP request failed")
+    else
+      print("HTTP request success")
+      print(code, data)
+    end
     node.dsleep(0)
+  end)
 end)


### PR DESCRIPTION
This PR improves the doorbell service to wait until an IP address is assigned before performing the HTTP request. This was necessary to make it work on my home network, hopefully it might also improve the reliability of the office's node. This requires flashing a new firmware which includes the HTTP module.
