### PR TITLE
Monitor the STA_GOTIP event instead of polling for waiting for an IP

### DIFF
--- a/door-open-service/esp8266-nodemcu/init.lua
+++ b/door-open-service/esp8266-nodemcu/init.lua
@@ -13,16 +13,18 @@ gpio.write(gpio_pin, gpio.LOW)
 
 -- 3. Set-up timer
 function setup_alarm()
-  tmr.alarm(0, 3000, 1, function ()
-    local ip = wifi.sta.getip()
-    if ip then
-      tmr.stop(0)
+  if wifi.sta.getip() then
+    connect_to_sf_service()
+  else
+    configure_wifi()
+    wifi.sta.eventMonReg(wifi.STA_GOTIP, function()
+      wifi.sta.eventMonStop()
       connect_to_sf_service()
-    else
-      configure_wifi()
-    end
-  end)
+    end)
+    wifi.sta.eventMonStart()
+  end
 end
+
 setup_alarm()
 
 function connect_to_sf_service()

--- a/door-open-service/esp8266-nodemcu/init.lua
+++ b/door-open-service/esp8266-nodemcu/init.lua
@@ -12,7 +12,7 @@ gpio.mode(gpio_pin, gpio.OUTPUT)
 gpio.write(gpio_pin, gpio.LOW)
 
 -- 3. Set-up timer
-function setup_alarm()
+function setup_wifi()
   if wifi.sta.getip() then
     connect_to_sf_service()
   else
@@ -25,7 +25,7 @@ function setup_alarm()
   end
 end
 
-setup_alarm()
+setup_wifi()
 
 function connect_to_sf_service()
   print("Connecting to backend service...")
@@ -36,7 +36,7 @@ function connect_to_sf_service()
   end)
   sk:connect(8300, "<BACKEND_SERVICE>")
   sk:on("connection", function(sck, c) print('got connection') end)
-  sk:on("disconnection", setup_alarm)
+  sk:on("disconnection", setup_wifi)
 end
 
 -- 4. Handle door relay

--- a/door-open-service/esp8266-nodemcu/init.lua
+++ b/door-open-service/esp8266-nodemcu/init.lua
@@ -16,12 +16,12 @@ function setup_alarm()
   if wifi.sta.getip() then
     connect_to_sf_service()
   else
-    configure_wifi()
     wifi.sta.eventMonReg(wifi.STA_GOTIP, function()
       wifi.sta.eventMonStop()
       connect_to_sf_service()
     end)
     wifi.sta.eventMonStart()
+    configure_wifi()
   end
 end
 

--- a/doorbell-service/esp8266-nodemcu/init.lua
+++ b/doorbell-service/esp8266-nodemcu/init.lua
@@ -8,22 +8,12 @@ local BACKEND_SERVICE_URL = "http://<BACKEND_SERVICE_HOST>/api/chat.postMessage"
   "&link_names=1" ..
   "&text=%40here%3a+Someone%20is%20ringing%20the%20door%20bell!"
 
-function wait_until(condition, action)
-  local WAIT_TIME = 150
-  tmr.alarm(0, WAIT_TIME, 1, function()
-    if condition() then
-      tmr.stop(0)
-      action()
-    else
-      tmr.start(0)
-    end
-  end)
-end
-
 wifi.setmode(wifi.STATION)
 wifi.sta.config(WIFI_SSID, WIFI_PASSWORD)
 
-wait_until(wifi.sta.getip, function()
+wifi.sta.eventMonReg(wifi.STA_GOTIP, function()
+  wifi.sta.eventMonStop()
+  
   http.post(BACKEND_SERVICE_URL, nil, nil, function(code, data)
     if code < 0 then
       print("HTTP request failed")
@@ -34,3 +24,5 @@ wait_until(wifi.sta.getip, function()
     node.dsleep(0)
   end)
 end)
+
+wifi.sta.eventMonStart()

--- a/doorbell-service/esp8266-nodemcu/init.lua
+++ b/doorbell-service/esp8266-nodemcu/init.lua
@@ -8,9 +8,6 @@ local BACKEND_SERVICE_URL = "http://<BACKEND_SERVICE_HOST>/api/chat.postMessage"
   "&link_names=1" ..
   "&text=%40here%3a+Someone%20is%20ringing%20the%20door%20bell!"
 
-wifi.setmode(wifi.STATION)
-wifi.sta.config(WIFI_SSID, WIFI_PASSWORD)
-
 wifi.sta.eventMonReg(wifi.STA_GOTIP, function()
   wifi.sta.eventMonStop()
   
@@ -26,3 +23,6 @@ wifi.sta.eventMonReg(wifi.STA_GOTIP, function()
 end)
 
 wifi.sta.eventMonStart()
+
+wifi.setmode(wifi.STATION)
+wifi.sta.config(WIFI_SSID, WIFI_PASSWORD)


### PR DESCRIPTION
Makes both `init.lua` scripts listen for `STA_GOTIP` events instead of polling for `wifi.sta.getip()`.
