### PR TITLE
Major overhaul to the node-backend

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,63 @@
+###############################################################################
+# Set default behavior to automatically normalize line endings.
+###############################################################################
+* text=auto
+
+###############################################################################
+# Set default behavior for command prompt diff.
+#
+# This is need for earlier builds of msysgit that does not have it on by
+# default for csharp files.
+# Note: This is only used by command line
+###############################################################################
+#*.cs     diff=csharp
+
+###############################################################################
+# Set the merge driver for project and solution files
+#
+# Merging from the command prompt will add diff markers to the files if there
+# are conflicts (Merging from VS is not affected by the settings below, in VS
+# the diff markers are never inserted). Diff markers may cause the following 
+# file extensions to fail to load in VS. An alternative would be to treat
+# these files as binary and thus will always conflict and require user
+# intervention with every merge. To do so, just uncomment the entries below
+###############################################################################
+#*.sln       merge=binary
+#*.csproj    merge=binary
+#*.vbproj    merge=binary
+#*.vcxproj   merge=binary
+#*.vcproj    merge=binary
+#*.dbproj    merge=binary
+#*.fsproj    merge=binary
+#*.lsproj    merge=binary
+#*.wixproj   merge=binary
+#*.modelproj merge=binary
+#*.sqlproj   merge=binary
+#*.wwaproj   merge=binary
+
+###############################################################################
+# behavior for image files
+#
+# image files are treated as binary by default.
+###############################################################################
+#*.jpg   binary
+#*.png   binary
+#*.gif   binary
+
+###############################################################################
+# diff behavior for common document formats
+# 
+# Convert binary document formats to text before diffing them. This feature
+# is only available from the command line. Turn it on by uncommenting the 
+# entries below.
+###############################################################################
+#*.doc   diff=astextplain
+#*.DOC   diff=astextplain
+#*.docx  diff=astextplain
+#*.DOCX  diff=astextplain
+#*.dot   diff=astextplain
+#*.DOT   diff=astextplain
+#*.pdf   diff=astextplain
+#*.PDF   diff=astextplain
+#*.rtf   diff=astextplain
+#*.RTF   diff=astextplain

--- a/door-open-service/node-backend/.gitignore
+++ b/door-open-service/node-backend/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+typings
+.vscode
+*.db

--- a/door-open-service/node-backend/app.js
+++ b/door-open-service/node-backend/app.js
@@ -69,12 +69,9 @@ bot.on('message', rawData => {
           const savedTime = Math.round(count * 40.0);
           const savedTimeStr = moment.duration(savedTime, 'seconds').humanize();
           const timeStr = moment(stats.since, moment.ISO_8601).fromNow();
-          let msg = 'The remote door opening service was used ' + count + ' time(s) since ' + timeStr + '.';
-          msg += '\nBreakdown by day:';
-          msg += '\n```';
-          msg += histogram(_.omit(stats, 'since'), { sort: false });
-          msg += '```';
-          msg += '\nAssuming that it takes ~40 seconds to open the door and get back, around ' + savedTimeStr + ' have been saved!';
+          const msg = `The remote door opening service was used ${count} time${count > 1 ? 's' : ''} since ${timeStr}.` +
+            `\nBreakdown by day:\n\`\`\`${histogram(_.omit(stats, 'since'), { sort: false })}\`\`\`` +
+            `\nAssuming that it takes ~40 seconds to open the door and get back, around ${savedTimeStr} have been saved!`;
           bot.postMessageToChannel(CHANNEL, msg);
         }).catch(err => {
           console.log(err);

--- a/door-open-service/node-backend/app.js
+++ b/door-open-service/node-backend/app.js
@@ -1,152 +1,153 @@
-var StringDecoder = require('string_decoder').StringDecoder;
-var decoder = new StringDecoder('utf8');
-var sqlite3 = require('sqlite3').verbose();
-var histogram = require('ascii-histogram');
-net = require('net');
+'use strict';
 
-var clients = [];
+const Hapi = require('hapi');
+const Joi = require('joi');
+const Boom = require('boom');
+const histogram = require('bars');
+const moment = require('moment');
+const Promise = require('bluebird');
+const Good = require('good');
+const SlackBot = require('slackbots');
+const net = require('net');
+const _ = require('underscore');
+const BellServer = require('./bellServer');
+const backend = require('./backend');
 
-net.createServer(function (socket) {
+const CHANNEL = '<CHANNEL_NAME>';
+const SLACK_TOKEN = '<SLACK_TOKEN>';
+const BOT_NAME = '<DOOR_BOT_NAME>';
+const SECRET = 'secret';
+const BELL_SERVER_PORT = 8300;
+const API_SERVER_PORT = 3000;
 
-  // Identify this client
-  socket.name = socket.remoteAddress + ":" + socket.remotePort;
+const server = new Hapi.Server();
+server.connection({ port: API_SERVER_PORT });
 
-  // Put this new client in the list
-  clients.push(socket);
-  console.log("New connection:");
-  console.log(socket);
-
-  // Handle incoming messages from clients.
-  socket.on('data', function (data) {
-    console.log(decoder.write(data));
-  });
-
-  // Remove the client from the list when it leaves
-  socket.on('end', function () {
-    console.log("end");
-    var clientIndex = clients.indexOf(socket);
-    if (clientIndex != -1) {
-      clients.splice(clientIndex, 1);
-    }
-  });
-
-  socket.on("error", function (err) {
-    console.log("Caught flash policy server socket error: ");
-    console.log(err.stack);
-    var clientIndex = clients.indexOf(socket);
-    if (clientIndex != -1) {
-      clients.splice(clientIndex, 1);
-    }
-  });
-
-  socket.on("close", function () {
-    console.log("Caught close.");
-    var clientIndex = clients.indexOf(socket);
-    if (clientIndex != -1) {
-      clients.splice(clientIndex, 1);
-    }
-  });
-}).listen(8300);
-
-// Send a message to all clients
-function broadcast(message) {
-  clients.forEach(function (client) {
-    // Don't want to send it to sender
-    client.write(message);
-  });
-  // Log it to the server output too
-  process.stdout.write(message)
-}
-
-process.stdin.resume();
-process.stdin.setEncoding('utf8');
-
-process.stdin.on('data', function (chunk) {
-  broadcast(chunk);
+const bellServer = new BellServer({
+  port: BELL_SERVER_PORT
 });
 
-
-// Slack integration
-// ------------------------------------------------------------------
-var request = require('request');
-var RtmClient = require('@slack/client').RtmClient;
-var RTM_CLIENT_EVENTS = require('@slack/client').CLIENT_EVENTS.RTM;
-var RTM_EVENTS = require('@slack/client').RTM_EVENTS;
-var STATS_DATABASE = "stats.db";
-var token = '<SLACK_TOKEN>';
-var doorbot = '<DOOR_BOT_ID>';
-var channel = '<CHANNEL_ID>';
-
-var SlackWebClient = require('@slack/client').WebClient;
-var web = new SlackWebClient(token, {});
-
-function getUserId(userId, userInfoCb) {
-  web.users.info(userId, userInfoCb);
-}
-
-var db = new sqlite3.Database(STATS_DATABASE);
-db.serialize(function() {
-  db.run("CREATE TABLE IF NOT EXISTS door_opens(id INTEGER PRIMARY KEY AUTOINCREMENT, user TEXT, email TEXT, timestamp TEXT DEFAULT CURRENT_TIMESTAMP);");
+// create a bot
+const bot = new SlackBot({
+    token: SLACK_TOKEN,
+    name: BOT_NAME
 });
-var days_of_week = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
 
-var rtm = new RtmClient(token, {logLevel: 'debug'});
-rtm.start();
-
-rtm.on(RTM_CLIENT_EVENTS.RTM_CONNECTION_OPENED, function () {
-  rtm.on(RTM_EVENTS.MESSAGE, function (message) {
-    console.log(message);
-    if (message.channel == channel && message.text != null && message.text.match(doorbot) != null) {
-      if (message.text.match(/open/i) != null) {
-        if (clients.length > 0) {
-          getUserId(message.user, function userInfoCb(err, info) {
-            if (err) {
-              console.log('Error:', err);
-            } else {
-              rtm.sendMessage('Opening the door as requested by ' + info.user.name + ' (' + info.user.profile.email + ')...', channel);
-              db.run("INSERT INTO door_opens(user, email) VALUES(?, ?)", info.user.name, info.user.profile.email);
-              broadcast("2500");
-            }
-          });
+bot.on('message', rawData => {
+  console.log('bot: ' + JSON.stringify(rawData));
+  
+  if (rawData.type !== 'message') {
+    return;
+  }
+  
+  const text = rawData.text;
+  const channelId = rawData.channel;
+  const user = rawData.user;
+  
+  if (!text || !channelId) {
+    return;
+  }
+  
+  Promise.props({
+    channel: bot.getChannel(CHANNEL),
+    bot: bot.getUser(BOT_NAME)
+  }).then(data => {
+    if (channelId === data.channel.id && text && text.indexOf(bot.self.id) != -1) {
+      if (text.match(/open/i) != null) {
+        if (bellServer.available()) {
+          backend.openDoor(user, SECRET, bot, bellServer, CHANNEL, SECRET);
         } else {
-          rtm.sendMessage('The remote door opening service is not operational at the moment. Consider dispatching a drone to pick up a human.', channel);
+          bot.postMessageToChannel(CHANNEL, 'The remote door opening service is not operational at the moment. Consider dispatching a drone to pick up a human.');
         }
-      } else if (message.text.match(/stats/i) != null) {
-        db.get("SELECT COUNT(*) as count FROM door_opens", function(err, r1) {
-          if (err) {
-            console.log('Error:', err);
-          } else if (r1) {
-            db.get("SELECT timestamp FROM door_opens ORDER BY timestamp ASC LIMIT 1", function(err, r2) {
-              if (err) {
-                console.log('Error:', err);
-              } else if (r2) {
-                var msg = 'The remote door opening service was used ' + r1.count + ' time(s) since ' + r2.timestamp + '.';
-                var counts = {};
-                days_of_week.forEach(function(el) { counts[el] = 0; });
-                db.each("SELECT case cast(strftime('%w', timestamp) as integer)\
-                         when 0 then 'Sun'\
-                         when 1 then 'Mon'\
-                         when 2 then 'Tue'\
-                         when 3 then 'Wed'\
-                         when 4 then 'Thu'\
-                         when 5 then 'Fri'\
-                         else 'Sat' end as dayofweek, COUNT(*) as count FROM door_opens GROUP BY dayofweek", function(err, r3) {
-                           counts[r3.dayofweek] = r3.count;
-                         }, function() {
-                           msg += '\nBreakdown by day:';
-                           msg += '\n```';
-                           msg += histogram(counts, { sort: false });
-                           msg += '```';
-                           msg += '\nAssuming that it takes ~40 seconds to open the door and get back, around ' + Math.round((r1.count * 40)/60) + ' minutes have been saved!';
-                           rtm.sendMessage(msg, channel);
-                         });
-              }
-            });
-          } else {
-            rtm.sendMessage('There are no available stats for the remote door opening service', channel);
+      } else if (text.match(/stats/i) != null) {
+        return backend.getStats().then(stats => {
+          if (!stats) {
+            throw new Error('There are no available stats for the remote door opening service');
           }
+
+          const count = _.reduce(_.values(_.omit(stats, 'since')), (m, val) => m + val, 0);
+          const savedTime = Math.round((count * 40.0)/60.0);
+          const timeStr = moment(stats.since, moment.ISO_8601).fromNow();
+          let msg = 'The remote door opening service was used ' + count + ' time(s) since ' + timeStr + '.';
+          msg += '\nBreakdown by day:';
+          msg += '\n```';
+          msg += histogram(_.omit(stats, 'since'), { sort: false });
+          msg += '```';
+          msg += '\nAssuming that it takes ~40 seconds to open the door and get back, around ' + savedTime + ' minutes have been saved!';
+          bot.postMessageToChannel(CHANNEL, msg);
+        }).catch(err => {
+          console.log(err);
+          bot.postMessageToChannel(CHANNEL, err.message);
         });
       }
     }
+  }).catch(err => console.log(err));
+});
+
+// GET /ping
+server.route({
+  method: 'GET',
+  path: '/ping',
+  handler: (request, reply) => {
+    reply('I\'m alive.');
+  }
+});
+
+// GET /stats
+server.route({
+  method: 'GET',
+  path: '/stats',
+  handler: (request, reply) => {
+    backend.getStats()
+      .then(data => reply(data))
+      .catch(err => { console.log(err); reply(err); });
+  }
+});
+
+// POST /open
+server.route({
+  method: 'POST',
+  path: '/open',
+  handler: (request, reply) => {
+    backend.openDoor(request.payload.id, request.payload.secret, bot, bellServer, CHANNEL, SECRET).then(user => {
+      if (!user) {
+        reply(Boom.unauthorized());
+      } else {
+        reply(user);
+      }
+    }).catch(err => { console.log(err); reply(err) });
+  },
+  config: {
+    validate: {
+      payload: {
+        id: Joi.string(),
+        secret: Joi.string()
+      }
+    }
+  }
+});
+
+server.register({
+  register: Good,
+  options: {
+    reporters: [{
+      reporter: require('good-console'),
+      events: {
+        response: '*',
+        log: '*'
+      }
+    }]
+  }
+}, err => {
+  if (err) {
+    throw err; // something bad happened loading the plugin
+  }
+
+  server.start((err) => {
+    if (err) {
+      throw err;
+    }
+
+    server.log('info', 'Server running at: ' + server.info.uri);
   });
 });

--- a/door-open-service/node-backend/app.js
+++ b/door-open-service/node-backend/app.js
@@ -66,14 +66,15 @@ bot.on('message', rawData => {
           }
 
           const count = _.reduce(_.values(_.omit(stats, 'since')), (m, val) => m + val, 0);
-          const savedTime = Math.round((count * 40.0)/60.0);
+          const savedTime = Math.round(count * 40.0);
+          const savedTimeStr = moment.duration(savedTime, 'seconds').humanize();
           const timeStr = moment(stats.since, moment.ISO_8601).fromNow();
           let msg = 'The remote door opening service was used ' + count + ' time(s) since ' + timeStr + '.';
           msg += '\nBreakdown by day:';
           msg += '\n```';
           msg += histogram(_.omit(stats, 'since'), { sort: false });
           msg += '```';
-          msg += '\nAssuming that it takes ~40 seconds to open the door and get back, around ' + savedTime + ' minutes have been saved!';
+          msg += '\nAssuming that it takes ~40 seconds to open the door and get back, around ' + savedTimeStr + ' have been saved!';
           bot.postMessageToChannel(CHANNEL, msg);
         }).catch(err => {
           console.log(err);

--- a/door-open-service/node-backend/backend.js
+++ b/door-open-service/node-backend/backend.js
@@ -1,0 +1,102 @@
+'use strict';
+
+const Sequelize = require('sequelize');
+const _ = require('underscore');
+const Promise = require('bluebird');
+
+const STATS_DATABASE = 'stats.db'; // sqlite
+const DAYS_OF_WEEK = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+
+const sequelize = new Sequelize(null, null, null, {
+  dialect: 'sqlite',
+  storage: STATS_DATABASE
+});
+
+const DoorOpens = sequelize.define('door_opens', {
+  id: {
+    type: Sequelize.INTEGER,
+    field: 'id',
+    primaryKey: true,
+    autoIncrement: true
+  },
+  user: {
+    type: Sequelize.STRING,
+    field: 'user'
+  },
+  email: {
+    type: Sequelize.STRING,
+    field: 'email'
+  },
+  timestamp: {
+    type: Sequelize.DATE,
+    field: 'timestamp',
+    defaultValue: Sequelize.NOW
+  }
+}, {
+  freezeTableName: true,
+  tableName: 'door_opens',
+  timestamps: false
+});
+
+DoorOpens.sync();
+
+exports.getStats = function () {
+  const queries = {
+    count_per_dayQ: sequelize.query(
+      "SELECT case cast(strftime('%w', timestamp) as integer) " +
+      "when 0 then 'Sun' " +
+      "when 1 then 'Mon' " +
+      "when 2 then 'Tue' " +
+      "when 3 then 'Wed' " +
+      "when 4 then 'Thu' " +
+      "when 5 then 'Fri' " +
+      "else 'Sat' end as dayofweek, COUNT(timestamp) as count FROM door_opens GROUP BY dayofweek", {
+      type: sequelize.QueryTypes.SELECT
+    }),
+    timestampQ: DoorOpens.findOne({
+      order: 'timestamp ASC',
+      limit: 1,
+      attributes: ['timestamp',],
+    })
+  };
+
+  return Promise.props(queries)      
+  .then(data => {
+    const counts0 = _.object(DAYS_OF_WEEK, _.map(DAYS_OF_WEEK, val => 0));
+    const countsDay = _.chain(data.count_per_dayQ).indexBy('dayofweek').mapObject(day => day.count).value();
+    const full = _.extendOwn(counts0, countsDay, { since: data.timestampQ ? new Date(data.timestampQ.timestamp).toISOString() : null });
+    
+    return full;
+  });
+};
+
+exports.openDoor = function(userId, secret, slackBot, bellServer, channel, serverSecret) {
+  if (secret != serverSecret) {
+    return Promise.resolve(null);
+  }
+
+  return slackBot.getUsers().then(usersRaw => {
+    const id = userId;
+    const users = _.chain(usersRaw.members).indexBy('id').mapObject(user => {
+      return {
+        email: user.profile ? (user.profile.email ? user.profile.email : '') : '',
+        name: user.name
+      }
+    }).value();
+    
+    if (_.has(users, id)) {
+      const user = users[id];
+      DoorOpens.create({
+        user: user.name,
+        email: user.email
+      });
+      
+      bellServer.broadcast('2500');
+      slackBot.postMessageToChannel(channel, 'Opening the door as requested by ' + user.name + ' (' + user.email + ')...');
+
+      return user;
+    } else {
+      return null;
+    }
+  });
+};

--- a/door-open-service/node-backend/bellServer.js
+++ b/door-open-service/node-backend/bellServer.js
@@ -1,0 +1,67 @@
+'use strict';
+
+const net = require('net');
+
+function BellServer(params) {
+  this.port = params.port;
+  this.clients = [];
+  
+  this.createServer();
+}
+
+BellServer.prototype.available = function() {
+  return this.clients.size != 0;
+}
+
+BellServer.prototype.createServer = function() {
+  return net.createServer(socket => {
+
+    // Identify this client
+    socket.name = socket.remoteAddress + ':' + socket.remotePort;
+
+    // Put this new client in the list
+    this.clients.push(socket);
+    console.log('New connection:');
+    console.log(socket);
+
+    // Handle incoming messages from clients.
+    socket.on('data', data => {
+      console.log(decoder.write(data));
+    });
+
+    // Remove the client from the list when it leaves
+    socket.on('end', () => {
+      console.log('end');
+      const clientIndex = this.clients.indexOf(socket);
+      if (clientIndex != -1) {
+        this.clients.splice(clientIndex, 1);
+      }
+    });
+
+    socket.on('error', (err) => {
+      console.log('Caught flash policy server socket error: ');
+      console.log(err.stack);
+      const clientIndex = this.clients.indexOf(socket);
+      if (clientIndex != -1) {
+        this.clients.splice(clientIndex, 1);
+      }
+    });
+
+    socket.on('close', () => {
+      console.log('Caught close.');
+      const clientIndex = this.clients.indexOf(socket);
+      if (clientIndex != -1) {
+        this.clients.splice(clientIndex, 1);
+      }
+    });
+  }).listen(this.port);
+};
+
+// Send a message to all clients
+BellServer.prototype.broadcast = function(message) {
+  this.clients.forEach(client => client.write(message)); // Don't want to send it to sender
+  // Log it to the server output too
+  process.stdout.write(message);
+};
+
+module.exports = BellServer;

--- a/door-open-service/node-backend/jsconfig.json
+++ b/door-open-service/node-backend/jsconfig.json
@@ -1,0 +1,6 @@
+{
+    "compilerOptions": {
+        "target": "es5",
+        "module": "commonjs"
+    }
+}

--- a/door-open-service/node-backend/package.json
+++ b/door-open-service/node-backend/package.json
@@ -6,16 +6,26 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "author": "",
-  "license": "ISC",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/FoundersFounders/door-services.git"
+  },
+  "author": "FoundersFounders",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/FoundersFounders/door-services/issues"
+  },
+  "homepage": "https://github.com/FoundersFounders/door-services#readme",
   "dependencies": {
-    "ascii-histogram": "1.2.0",
-    "@slack/client": "^2.0.5",
-    "basic-auth-connect": "^1.0.0",
-    "requestify": "^0.1.17",
+    "bars": "github:steel/bars",
+    "bluebird": "^3.3.4",
+    "good": "^6.6.0",
+    "good-console": "^5.3.1",
+    "hapi": "^13.2.1",
+    "moment": "^2.12.0",
+    "sequelize": "^3.19.3",
+    "slackbots": "^0.5.1",
     "sqlite3": "^3.1.1",
-    "string_decoder": "^0.10.31",
-    "url": "^0.11.0",
-    "ws": "^1.0.1"
+    "underscore": "^1.8.3"
   }
 }


### PR DESCRIPTION
- Implement a simple HTTP API to open the door and retrieve stats, powered by hapi.js
- Replace the low level RTM Slack module by SlackBots
- Replace some hardcoded SQL queries by an ORM*, powered by Sequelize
- Split the code in multiple files (app, backend and bellServer)
- Slack channel and bot identifiers were replaced by lookups of their names
- The table schema was not changed

The API is as follows:

**GET /ping**: returns 200

**GET /stats**: returns the number of door openings per week day and the timestamp of the first door open:

``` json
{
    "Sun": 0,
    "Mon": 24,
    "Tue": 26,
    "Wed": 30,
    "Thu": 1,
    "Fri": 0,
    "Sat": 0,
    "since": "2016-03-14T15:26:32.000Z"
}
```

**POST /open**: opens the door, params are `id`: the Slack user id of the person opening the door (must be in the slack channel) and `secret`: a "password"/token shared by the ones with access to the door. Returns some JSON user params if authorized, 401 otherwise.

The interaction with the bot on Slack was not changed.
This was tested with a real slack bot however it was not tested with the doorbell itself.
