### PR TITLE
Garage open support

### DIFF
--- a/door-open-service/esp8266-nodemcu/init.lua
+++ b/door-open-service/esp8266-nodemcu/init.lua
@@ -3,10 +3,10 @@
 local WIFI_SSID = "<WIFI_SSID>"
 local WIFI_PASSWORD = "<WIFI_PASSWORD>"
 local BACKEND_SERVICE = "<BACKEND_SERVICE>"
+local DOOR_GROUP = "door"
 
 -- 1. Connect to wifi
 function configure_wifi()
-  wifi.setmode(wifi.STATION)
   wifi.sta.config(WIFI_SSID, WIFI_PASSWORD)
 end
 
@@ -17,6 +17,8 @@ gpio.write(gpio_pin, gpio.LOW)
 
 -- 3. Set-up timer
 function setup_wifi()
+  wifi.setmode(wifi.STATION)
+  
   if wifi.sta.getip() then
     connect_to_sf_service()
   else
@@ -39,7 +41,10 @@ function connect_to_sf_service()
     print(c)
   end)
   sk:connect(8300, BACKEND_SERVICE)
-  sk:on("connection", function(sck, c) print('got connection') end)
+  sk:on("connection", function(sck, c)
+    print("got connection")
+    sk:send("G|"..DOOR_GROUP)
+  end)
   sk:on("disconnection", setup_wifi)
 end
 

--- a/door-open-service/esp8266-nodemcu/init.lua
+++ b/door-open-service/esp8266-nodemcu/init.lua
@@ -3,7 +3,7 @@
 local WIFI_SSID = "<WIFI_SSID>"
 local WIFI_PASSWORD = "<WIFI_PASSWORD>"
 local BACKEND_SERVICE = "<BACKEND_SERVICE>"
-local DOOR_GROUP = "door"
+local DOOR_GROUP = "door" -- change if not deploying for the front door
 
 -- 1. Connect to wifi
 function configure_wifi()

--- a/door-open-service/node-backend/app.js
+++ b/door-open-service/node-backend/app.js
@@ -57,17 +57,17 @@ channelInfoPromise.then(channelInfo => {
     }
 
     if (channelId === targetChannelId && text && text.indexOf(bot.self.id) != -1) {
-      if (text.match(/open/i) != null) {
-        if (bellServer.available('door')) {
-          backend.openDoor(user, SECRET, bot, bellServer, CHANNEL, SECRET);
-        } else {
-          bot[postMessageMethod](CHANNEL.name, 'The remote door opening service is not operational at the moment. Consider dispatching a drone to pick up a human.', { as_user: 'true' });
-        }
-      } else if (text.match(/garage/i) != null) {
+      if (text.match(/garage/i) != null) {
         if (bellServer.available('garage')) {
           backend.openGarage(user, SECRET, bot, bellServer, CHANNEL, SECRET);
         } else {
           bot[postMessageMethod](CHANNEL.name, 'The remote garage opening service is not operational at the moment. Consider dispatching a drone to pick up a human.', { as_user: 'true' });
+        }
+      } else if (text.match(/open/i) != null) {
+        if (bellServer.available('door')) {
+          backend.openDoor(user, SECRET, bot, bellServer, CHANNEL, SECRET);
+        } else {
+          bot[postMessageMethod](CHANNEL.name, 'The remote door opening service is not operational at the moment. Consider dispatching a drone to pick up a human.', { as_user: 'true' });
         }
       } else if (text.match(/stats/i) != null) {
         return backend.getStats().then(stats => {

--- a/door-open-service/node-backend/app.js
+++ b/door-open-service/node-backend/app.js
@@ -58,10 +58,16 @@ channelInfoPromise.then(channelInfo => {
 
     if (channelId === targetChannelId && text && text.indexOf(bot.self.id) != -1) {
       if (text.match(/open/i) != null) {
-        if (bellServer.available()) {
+        if (bellServer.available('door')) {
           backend.openDoor(user, SECRET, bot, bellServer, CHANNEL, SECRET);
         } else {
           bot[postMessageMethod](CHANNEL.name, 'The remote door opening service is not operational at the moment. Consider dispatching a drone to pick up a human.', { as_user: 'true' });
+        }
+      } else if (text.match(/garage/i) != null) {
+        if (bellServer.available('garage')) {
+          backend.openGarage(user, SECRET, bot, bellServer, CHANNEL, SECRET);
+        } else {
+          bot[postMessageMethod](CHANNEL.name, 'The remote garage opening service is not operational at the moment. Consider dispatching a drone to pick up a human.', { as_user: 'true' });
         }
       } else if (text.match(/stats/i) != null) {
         return backend.getStats().then(stats => {

--- a/door-open-service/node-backend/backend.js
+++ b/door-open-service/node-backend/backend.js
@@ -70,7 +70,7 @@ exports.getStats = function () {
   });
 };
 
-exports.openDoor = function(userId, secret, slackBot, bellServer, channel, serverSecret) {
+function openStuff(whatStuff, userId, secret, slackBot, bellServer, channel, serverSecret) {
   const postMessageMethod = channel.private ? 'postMessageToGroup' : 'postMessageToChannel';
 
   if (secret != serverSecret) {
@@ -92,13 +92,21 @@ exports.openDoor = function(userId, secret, slackBot, bellServer, channel, serve
         user: user.name,
         email: user.email
       });
-
-      bellServer.broadcast('2500');
-      slackBot[postMessageMethod](channel.name, 'Opening the door as requested by ' + user.name + ' (' + user.email + ')...', { as_user: 'true' });
+      
+      bellServer.broadcast(whatStuff, '2500');
+      slackBot[postMessageMethod](channel.name, 'Opening the ' + whatStuff + ' as requested by ' + user.name + ' (' + user.email + ')...', { as_user: 'true' });
 
       return user;
     } else {
       return null;
     }
   });
+};
+
+exports.openDoor = function(userId, secret, slackBot, bellServer, channel, serverSecret) {
+  openStuff('door', userId, secret, slackBot, bellServer, channel, serverSecret);
+};
+
+exports.openGarage = function(userId, secret, slackBot, bellServer, channel, serverSecret) {
+  openStuff('garage', userId, secret, slackBot, bellServer, channel, serverSecret);
 };


### PR DESCRIPTION
Adds support in the backend server and in the NodeMCU client code for multiple types of door opening devices - in particular, adds support for garage opening devices. Each device may send to the server a "group" string that identifies the door they open. Please don't mind the hasty code; I plan to do a large-scale refactoring after this is working.

Tested locally with my ESP8266 and verified to be backwards-compatible with the current ESP8266 deployment. Depends on #6.
