### PR TITLE
Use the official Slack Node client

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - 5.0
+  - 6
 script:
   - cd door-open-service/node-backend && npm install && npm run lint
 env:

--- a/door-open-service/node-backend/config.json.template
+++ b/door-open-service/node-backend/config.json.template
@@ -1,10 +1,6 @@
 {
   "slack": {
-    "channel": {
-      "name": "<CHANNEL_NAME>",
-      "private": true
-    },
-    "botName": "<BOT_NAME>",
+    "channel": "<CHANNEL_NAME>",
     "botToken": "<BOT_TOKEN>"
   },
   "socketServer": {

--- a/door-open-service/node-backend/package.json
+++ b/door-open-service/node-backend/package.json
@@ -21,23 +21,23 @@
   "homepage": "https://github.com/FoundersFounders/door-services#readme",
   "dependencies": {
     "@slack/client": "3.1.0",
-    "babel-core": "6.7.4",
+    "babel-core": "6.8.0",
+    "babel-plugin-syntax-object-rest-spread": "6.8.0",
+    "babel-plugin-transform-object-rest-spread": "6.8.0",
+    "babel-preset-es2015": "6.6.0",
     "bars": "github:steel/bars",
-    "bluebird": "3.3.4",
-    "eslint": "2.5.1",
+    "bluebird": "3.3.5",
     "good": "6.6.0",
     "good-console": "5.3.1",
-    "hapi": "13.2.1",
-    "moment": "2.12.0",
-    "sequelize": "3.19.3",
-    "sqlite3": "3.1.1",
+    "hapi": "13.4.0",
+    "moment": "2.13.0",
+    "sequelize": "3.23.0",
+    "sqlite3": "3.1.3",
     "string_decoder": "0.10.31",
     "underscore": "1.8.3"
   },
   "devDependencies": {
-    "babel-eslint": "6.0.0",
-    "babel-plugin-syntax-object-rest-spread": "6.5.0",
-    "babel-plugin-transform-object-rest-spread": "6.6.5",
-    "babel-preset-es2015": "6.6.0"
+    "babel-eslint": "6.0.4",
+    "eslint": "2.9.0"
   }
 }

--- a/door-open-service/node-backend/package.json
+++ b/door-open-service/node-backend/package.json
@@ -20,6 +20,7 @@
   },
   "homepage": "https://github.com/FoundersFounders/door-services#readme",
   "dependencies": {
+    "@slack/client": "3.1.0",
     "babel-core": "6.7.4",
     "bars": "github:steel/bars",
     "bluebird": "3.3.4",
@@ -29,7 +30,6 @@
     "hapi": "13.2.1",
     "moment": "2.12.0",
     "sequelize": "3.19.3",
-    "slackbots": "0.5.1",
     "sqlite3": "3.1.1",
     "string_decoder": "0.10.31",
     "underscore": "1.8.3"


### PR DESCRIPTION
This PR replaces the `slackbots` dependency by `@slack/client`, which is maintained by Slack directly.

Like slackbots, it keeps an internal data store that [caches the team data](https://github.com/slackhq/node-slack-client/blob/master/lib/data-store/data-store.js#L373) (like channels and users) but it seems to [be handling](https://github.com/slackhq/node-slack-client/blob/master/lib/data-store/message-handlers/helpers.js#L17) user/channel CRUD events in order keep the store updated.

I did some experiments with network failures, like turning off the Wi-Fi for short and long periods of time, and it reconnected without any problem. There is a `DISCONNECT` event indicating a "permanent" client disconnection; I opted to log that event, but I would like to see if the problem we've been experience still occurs before handling the event the hard way (i.e. initializing the client and reconnect again).

The service is now logging a strange message on startup - [this one](https://github.com/slackhq/node-slack-client/blob/master/lib/clients/rtm/client.js#L540). I didn't found any event I could listen to avoid this, but it seems a pretty harmless message that is kinda expected, judging by the comments on the source code.
