### PR TITLE
Manage all dependencies using npm

### DIFF
--- a/mobile-app/.bowerrc
+++ b/mobile-app/.bowerrc
@@ -1,3 +1,0 @@
-{
-  "directory": "www/lib"
-}

--- a/mobile-app/.gitignore
+++ b/mobile-app/.gitignore
@@ -1,3 +1,6 @@
+npm-debug.log
+node_modules/
+
 platforms/
 plugins/
 www/lib/

--- a/mobile-app/README.md
+++ b/mobile-app/README.md
@@ -3,37 +3,37 @@
 Install the required dependencies:
 
 ```
-npm install -g cordova
-npm install -g cordova-icon
-npm install -g bower
-cordova prepare
-bower install
+npm install
 ```
 
 `cordova-icon` requires `ImageMagick`:
 
 ```
-brew install imagemagick # OSX
-sudo apt-get install imagemagick # Debian / Ubuntu
+brew install imagemagick            # OSX
+sudo apt-get install imagemagick    # Debian / Ubuntu
 ```
 
-To build the app for iOS you must also install:
+To build the app for iOS you must also install (locally or globally):
 
 ```
-npm install -g ios-sim
-npm install -g ios-deploy
+npm install ios-sim
+npm install ios-deploy
 ```
 
-To build the app:
+To build and run the app in the platform simulator:
 
 ```
-cordova build
+npm start                   # all platforms
+npm start android           # android app only
+npm start ios               # iOS app only
 ```
 
-To run the app in the platform simulator:
+To build the app only without running it:
 
 ```
-cordova run
+npm run build               # all platforms
+npm run build -- android    # android app only
+npm run build -- ios        # iOS app only
 ```
 
 # Reference

--- a/mobile-app/bower.json
+++ b/mobile-app/bower.json
@@ -1,7 +1,0 @@
-{
-  "name": "mobile-app",
-  "private": true,
-  "dependencies": {
-    "Framework7": "framework7#^1.4.2"
-  }
-}

--- a/mobile-app/package.json
+++ b/mobile-app/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "door-service-mobile-app",
+  "version": "0.1.0",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:FoundersFounders/door-services.git"
+  },
+  "license": "MIT",
+  "dependencies": {
+    "framework7": "^1.4.2"
+  },
+  "devDependencies": {
+    "cordova": "^6.1.1",
+    "cordova-icon": "^0.7.0"
+  },
+  "scripts": {
+    "jsres": "mkdir -p www/lib/js && cp node_modules/framework7/dist/js/*.js www/lib/js",
+    "cssres": "mkdir -p www/lib/css && cp node_modules/framework7/dist/css/*.css www/lib/css",
+    "postinstall": "npm run -s jsres && npm run -s cssres",
+    "requirements": "cordova requirements",
+    "build": "cordova build",
+    "start": "cordova run"
+  }
+}

--- a/mobile-app/package.json
+++ b/mobile-app/package.json
@@ -16,7 +16,7 @@
   "scripts": {
     "jsres": "mkdir -p www/lib/js && cp node_modules/framework7/dist/js/*.js www/lib/js",
     "cssres": "mkdir -p www/lib/css && cp node_modules/framework7/dist/css/*.css www/lib/css",
-    "postinstall": "npm run -s jsres && npm run -s cssres",
+    "postinstall": "npm run -s jsres && npm run -s cssres && cordova prepare",
     "requirements": "cordova requirements",
     "build": "cordova build",
     "start": "cordova run"

--- a/mobile-app/www/css/framework7.material.colors.min.css
+++ b/mobile-app/www/css/framework7.material.colors.min.css
@@ -1,1 +1,0 @@
-../lib/Framework7/dist/css/framework7.material.colors.min.css

--- a/mobile-app/www/css/framework7.material.min.css
+++ b/mobile-app/www/css/framework7.material.min.css
@@ -1,1 +1,0 @@
-../lib/Framework7/dist/css/framework7.material.min.css

--- a/mobile-app/www/index.html
+++ b/mobile-app/www/index.html
@@ -6,8 +6,8 @@
         <meta name="msapplication-tap-highlight" content="no">
         <meta charset="UTF-8">
         <meta name="viewport" content="user-scalable=no, initial-scale=1, maximum-scale=1, minimum-scale=1, width=device-width">
-        <link rel="stylesheet" type="text/css" href="css/framework7.material.min.css">
-        <link rel="stylesheet" type="text/css" href="css/framework7.material.colors.min.css">
+        <link rel="stylesheet" type="text/css" href="lib/css/framework7.material.min.css">
+        <link rel="stylesheet" type="text/css" href="lib/css/framework7.material.colors.min.css">
         <link rel="stylesheet" type="text/css" href="css/index.css">
         <title>Slack Stuff</title>
     </head>
@@ -27,7 +27,7 @@
         </div>
 
         <script type="text/javascript" src="cordova.js"></script>
-        <script type="text/javascript" src="js/framework7.min.js"></script>
+        <script type="text/javascript" src="lib/js/framework7.min.js"></script>
         <script type="text/javascript" src="js/app.js"></script>
     </body>
 </html>

--- a/mobile-app/www/js/app.js
+++ b/mobile-app/www/js/app.js
@@ -3,14 +3,16 @@ var $$ = Dom7;
 
 var app = {
 
+  // -- to be filled before compiling the app --
+  clientId: '<CLIENT_ID>',
+  clientSecret: '<CLIENT_SECRET>',
+  teamId: '<TEAM_ID>',
   channel: '<CHANNEL>',
-  token: '',
+  redirectUri: '<REDIRECT_URI>',
+  // --
 
-  clientId: 'CLIENT_ID',
-  clientSecret: 'CLIENT_SECRET',
+  token: '',
   requiredScope: 'chat:write:user',
-  redirectUri: 'REDIRECT_URI',
-  teamId: 'TEAM_ID',
 
   f7: new Framework7({
     material: true

--- a/mobile-app/www/js/framework7.min.js
+++ b/mobile-app/www/js/framework7.min.js
@@ -1,1 +1,0 @@
-../lib/Framework7/dist/js/framework7.min.js


### PR DESCRIPTION
This PR removes the bower dependency by making npm manage client-side dependencies too. It also adds utility npm scripts to make it easier for developers to test and deploy the app.

Using the process in README, cordova and cordova-icon are installed locally (i.e. inside `node_modules`) rather than globally. I tend to prefer installing dependencies that way as they are easier to manage, we avoid conflicts of using different dependency versions in different projects and we do not pollute our systems with more global commands :P. However, that is not consensual. Let me know if that is a problem :)
